### PR TITLE
Add db functions for postgres and redis

### DIFF
--- a/src/models/Model.ts
+++ b/src/models/Model.ts
@@ -1,0 +1,158 @@
+import { Knex } from 'knex';
+
+import * as db from '../utils/db';
+import logger from '../utils/logger';
+import * as object from '../utils/object';
+import * as connectionManager from '../utils/connectionManager';
+
+export type ConnectionResolver = () => Knex;
+
+class Model {
+  public static table: string;
+  public static connection?: Knex;
+
+  /**
+   * Binds a database connection to the model.
+   *
+   * @param {Knex} connection
+   * @returns {void}
+   */
+  public static bindConnection(connection: Knex): void {
+    logger.info('Binding database connection to the model (Lazy)');
+
+    this.connection = connection;
+  }
+
+  /**
+   * Binds a database connection to the model (chainable version of bindConnection()).
+   *
+   * @param {Knex} connection
+   * @returns {any}
+   */
+  public static bind(connection: Knex): any {
+    this.bindConnection(connection);
+
+    return this;
+  }
+
+  /**
+   * Resolves a database connection.
+   *
+   * Note: It would throw an Error on the run time if it couldn't resolve the
+   * connection by the time any DB methods are invoked on it.
+   * @returns {Knex}
+   */
+  public static getConnection(resolver?: ConnectionResolver): Knex {
+    if (this.connection) {
+      return this.connection;
+    }
+
+    /**
+     * Note: We need to resolve db connection everytime.
+     *
+     * Since, all database connection info is cached in Redis.
+     */
+    if (resolver) {
+      return resolver();
+    }
+
+    throw new Error('Cannot resolve the database connection.');
+  }
+
+  /**
+   * Generic query builder.
+   *
+   * @param {(qb: Knex | Transaction) => QueryBuilder} callback
+   * @param {Transaction} [trx]
+   * @returns {Promise<T[]>}
+   */
+  public static async buildQuery<T>(
+    callback: (qb: Knex | Knex.Transaction) => Knex.QueryBuilder,
+    trx?: Knex.Transaction
+  ): Promise<T[]> {
+    const qb = db.queryBuilder(this.getConnection(), trx);
+    const result = await callback(qb);
+
+    return object.toCamelCase<T[]>(result);
+  }
+
+  /**
+   * Finds a record based on the params.
+   * Returns null if no results were found.
+   *
+   * @param {object} [params={}]
+   * @param {Knex.Transaction} trx
+   * @returns {Promise<T | null>}
+   */
+  public static get<T>(params: object = {}, trx?: Knex.Transaction): Promise<T | null> {
+    return db.get<T>(this.getConnection(), this.table, params, trx);
+  }
+
+  /**
+   * Find record by it's id.
+   * Returns null if not found.
+   *
+   * @param {number} id
+   * @param {Knex.Transaction} trx
+   * @returns {Promise<T | null>}
+   */
+  public static getById<T>(id: number, trx?: Knex.Transaction): Promise<T | null> {
+    return db.getById<T>(this.getConnection(), this.table, id, trx);
+  }
+
+  /**
+   * Insert all records sent in data object.
+   *
+   * @param {(object | object[])} data
+   * @param {Transaction} [trx]
+   * @returns {Promise<T[]>}
+   */
+  public static insert<T>(data: object | object[], trx?: Knex.Transaction): Promise<T[]> {
+    return db.insert<T>(this.getConnection(), this.table, data, trx);
+  }
+
+  /**
+   * Update records by id.
+   *
+   * @param {number} id
+   * @param {object} params
+   * @param {Transaction} transaction
+   * @returns {Promise<object>}
+   */
+  public static updateById<T>(id: number | number[], params: object, trx?: Knex.Transaction): Promise<T[]> {
+    return db.updateById<T>(this.getConnection(), this.table, id, params, trx);
+  }
+
+  /**
+   * Delete row in table.
+   *
+   * @param {object} params
+   * @param {Transaction} trx
+   * @returns {Promise<T[]>}
+   */
+  public static delete<T>(params: object, trx?: Knex.Transaction): Promise<T[]> {
+    return db.remove<T>(this.getConnection(), this.table, params, trx);
+  }
+}
+
+/**
+ * Base model with injected connection resolver.
+ *
+ */
+class BaseModel extends Model {
+  /**
+   * Resolves a database connection.
+   *
+   * Note: It would throw an Error on the run time if it couldn't resolve the
+   * connection by the time any DB methods are invoked on it.
+   * @returns {Knex}
+   */
+  public static getConnection(): Knex {
+    return super.getConnection(connectionManager.getDatabaseConnection);
+  }
+}
+
+logger.info('Initializing base model');
+logger.info('Bind connection resolver for the base Model');
+
+export default BaseModel;

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,13 +34,13 @@ export const server = app.listen(app.get('port'), app.get('host'), () => {
 });
 
 server.on('listening', async function () {
-    await initRedisConnection();
-    await bindAppConnection();
-  });
-  
-  server.on('close', async function () {
-    disconnect();
-    await destroyConnection();
-  });
+  await initRedisConnection();
+  await bindAppConnection();
+});
+
+server.on('close', async function () {
+  disconnect();
+  await destroyConnection();
+});
 
 export default app;

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,10 @@ import express from 'express';
 import compression from 'compression';
 import * as bodyParser from 'body-parser';
 
+import { disconnect } from './utils/redis';
+import { generalRouter, appRouter } from './routes/rootRouter';
+import { initRedisConnection, bindAppConnection, destroyConnection } from './utils/connectionManager';
+
 const APP_PORT =
   (process.env.NODE_ENV === 'test' ? process.env.TEST_APP_PORT : process.env.APP_PORT) || process.env.PORT || '3000';
 const APP_HOST = process.env.APP_HOST || '0.0.0.0';
@@ -22,8 +26,21 @@ app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
 app.use(cors());
 
+app.use(generalRouter);
+app.use('/api/v1', appRouter);
+
 export const server = app.listen(app.get('port'), app.get('host'), () => {
   console.log(`Server started at http://${app.get('host')}:${app.get('port')}`);
 });
+
+server.on('listening', async function () {
+    await initRedisConnection();
+    await bindAppConnection();
+  });
+  
+  server.on('close', async function () {
+    disconnect();
+    await destroyConnection();
+  });
 
 export default app;

--- a/src/types/camelize.d.ts
+++ b/src/types/camelize.d.ts
@@ -1,0 +1,1 @@
+declare module 'camelize';

--- a/src/types/snakeize.d.ts
+++ b/src/types/snakeize.d.ts
@@ -1,0 +1,1 @@
+declare module 'snakeize';

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,0 +1,5 @@
+import { CamelCase } from 'type-fest';
+
+export type CamelCaseKeys<T> = {
+  [key in keyof T as CamelCase<key>]: T[key];
+};

--- a/src/utils/connectionManager.ts
+++ b/src/utils/connectionManager.ts
@@ -1,0 +1,178 @@
+import { Knex } from 'knex';
+import { isNil, isEmpty } from 'ramda';
+
+import * as db from './db';
+import config from '../config';
+import logger from './logger';
+import * as redis from './redis';
+import { fromJson } from './object';
+import BaseModel from '../models/Model';
+
+const processEnv = config.env;
+
+/**
+ * Creates a database instance for database.
+ *
+ * @returns {Knex}
+ */
+export function getDatabaseConnection(): Knex {
+  const dbConfig = {
+    client: 'pg',
+    connection: { ...config.database[processEnv] }
+  };
+
+  logger.info('Resolving database connection pool for database');
+
+  return db.createInstance(dbConfig);
+}
+
+const env = config.env;
+
+export async function initRedisConnection() {
+  try {
+    await redis.init();
+
+    logger.info('REDIS: Connection established');
+  } catch (err) {
+    logger.error('REDIS: Redis could not be initialized:', err);
+
+    process.exit(1);
+  }
+}
+
+export async function bindAppConnection() {
+  try {
+    let connection: DatabaseConfig | null;
+    connection = await getPersistedConnections();
+    if (!connection) {
+      const memoizedConnection = await createMemoizedConnections();
+      if (!memoizedConnection) throw Error('Something went wrong in establishing the connection with database.');
+
+      connection = memoizedConnection;
+    }
+
+    const knexConnection = db.createInstance(connection);
+    BaseModel.bindConnection(knexConnection);
+  } catch (err) {
+    throw Error('Something went wrong in establishing the connection with database.');
+  }
+}
+
+export async function destroyConnection() {
+  const connection = await getPersistedConnections();
+
+  if (!connection) return;
+
+  const knexConnection = db.createInstance(connection);
+  await knexConnection.destroy();
+}
+
+const CONN_PERSISTENCE_KEY = 'database_connections';
+
+export interface DatabaseConfig {
+  client: string;
+  connection: {
+    user: string;
+    host: string;
+    port: number;
+    database: string;
+    password: string;
+  };
+}
+
+/**
+ * Creates connection map for all apps given in common database.
+ *
+ * @returns {ConnectionMap}
+ */
+export function createConnection(): DatabaseConfig {
+  const dbConfig = {
+    client: 'pg',
+    connection: { ...config.database[env] }
+  };
+
+  return dbConfig;
+}
+
+/**
+ * Create memoized connections for database. If the connection map doesn't
+ * already exist in Redis, then create and return it. Otherwise, create the
+ * connections and persist them to Redis.
+ *
+ *
+ * @param {boolean} [forceUpdate=false]
+ * @returns {Promise<ConnectionMap>}
+ */
+export async function createMemoizedConnections(forceUpdate: boolean = false): Promise<DatabaseConfig | null> {
+  const connections = await getPersistedConnections();
+
+  const connectionsCacheMiss = isNil(connections) || isEmpty(connections);
+
+  if (!connectionsCacheMiss && !forceUpdate) {
+    logger.info(`Client connections and app info are cached; skipping update`);
+
+    return null;
+  }
+
+  // The connections are updated if the cache is cold (initial state),
+  // or when a force update is to be made
+  if (forceUpdate) {
+    logger.info(`Updating cached connections (force update).`);
+  } else {
+    logger.info(`Database connection cache is cold, creating..`);
+  }
+
+  const connection = await createConnection();
+
+  await persistConnections(connection);
+
+  return connection;
+}
+
+/**
+ * Persist connection for any given appId into Redis.
+ *
+ * @param {DatabaseConfig} connectionMap
+ */
+export async function persistConnections(connectionMap: DatabaseConfig) {
+  const value = marshalToString(connectionMap);
+
+  try {
+    await redis.set(CONN_PERSISTENCE_KEY, value);
+  } catch (err: any) {
+    logger.error(`Could not persist connections: ${err.message}`);
+  }
+}
+
+/**
+ * Retrieve the persisted connection map.
+ *
+ * @returns {Promise<DatabaseConfig | null>}
+ */
+export async function getPersistedConnections(): Promise<DatabaseConfig | null> {
+  const connString = await redis.get(CONN_PERSISTENCE_KEY);
+  if (!connString) return null;
+
+  return unmarshalStringToObject<DatabaseConfig>(connString);
+}
+
+/**
+ * Marshal a value to string so that it can be stored in Redis,
+ * because Redis doesn't support nested keys.
+ *
+ * @param {any} value
+ * @returns {String}
+ */
+function marshalToString(value: any) {
+  return JSON.stringify(value);
+}
+
+/**
+ * Unmarshal the string received from Redis into a concrete type.
+ *
+ * @param {string} str
+ * @returns {Object}
+ */
+function unmarshalStringToObject<T>(str: string): T {
+  return fromJson<T>(str);
+}

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -1,0 +1,182 @@
+import { knex, Knex } from 'knex';
+
+import logger from '../utils/logger';
+import * as object from '../utils/object';
+
+/**
+ * Check if the provided object is a knex connection instance.
+ *
+ * @param {any} obj
+ * @returns {boolean}
+ */
+export function isKnexInstance(obj: any): obj is Knex {
+  return !!(obj.prototype && obj.prototype.constructor && obj.prototype.constructor.name === 'knex');
+}
+
+/**
+ * Creates a knex database connection instance from
+ * the provided database configuration.
+ *
+ * @param {Knex.Config} dbConfig
+ * @returns {knex}
+ */
+export function createInstance(dbConfig: Knex.Config): Knex {
+  return knex(dbConfig);
+}
+
+/**
+ * Check database connection from provided knex params.
+ *
+ * @param {Knex.Config | Knex | Knex.Transaction} connection
+ * @returns {Promise<boolean>}
+ */
+export async function isValidConnection(connection: Knex.Config | Knex | Knex.Transaction): Promise<boolean> {
+  const conn = isKnexInstance(connection) ? connection : createInstance(connection);
+
+  try {
+    await conn.raw('SELECT 1');
+
+    return true;
+  } catch (err) {
+    logger.error('Cannot connect to database', err);
+
+    return false;
+  }
+}
+
+/**
+ * Returns a query builder instance depending on the provided transaction.
+ *
+ * @param {Knex} connection
+ * @param {Knex.Transaction} [trx]
+ * @returns {(Knex.Transaction | Knex)}
+ */
+export function queryBuilder(connection: Knex, trx?: Knex.Transaction): Knex.Transaction | Knex {
+  return trx || connection;
+}
+
+/**
+ * Push 'updated_at' key to params if the column exists in the table being updated.
+ *
+ * @param {Knex} connection
+ * @param {string} table
+ * @param {any} [params={}]
+ * @returns {Promise<any>}
+ */
+async function withTimestamp(connection: Knex, table: string, params: any = {}): Promise<any> {
+  const exists = await connection.schema.hasColumn(table, 'updated_at');
+
+  if (!exists || (exists && params.updatedAt)) {
+    return object.toSnakeCase(params);
+  }
+
+  return { ...object.toSnakeCase(params), updated_at: connection.fn.now() };
+}
+
+/**
+ * Finds a record based on the params.
+ * Returns null if no results were found.
+ *
+ * @param {Knex} connection
+ * @param {string} table
+ * @param {object} [params={}]
+ * @param {Knex.Transaction} [trx]
+ * @returns {(Promise<T | null>)}
+ */
+export async function get<T>(
+  connection: Knex,
+  table: string,
+  params: object = {},
+  trx?: Knex.Transaction
+): Promise<T | null> {
+  const [result] = await queryBuilder(connection, trx)
+    .select('*')
+    .from(table)
+    .where(object.toSnakeCase(params))
+    .limit(1);
+
+  if (!result) {
+    return null;
+  }
+
+  return object.toCamelCase(result);
+}
+
+/**
+ * Find record by it's id.
+ * Returns null if not found.
+ *
+ * @param {Knex} connection
+ * @param {string} table
+ * @param {number} id
+ * @returns {(Promise<T | null>)}
+ */
+export function getById<T>(connection: Knex, table: string, id: number, trx?: Knex.Transaction): Promise<T | null> {
+  return get<T>(connection, table, { id }, trx);
+}
+
+/**
+ * Insert all records sent in data object.
+ *
+ * @param {Knex} connection
+ * @param {string} table
+ * @param {(object | object[])} data
+ * @param {Knex.Transaction} [trx]
+ * @returns {Promise<T[]>}
+ */
+export async function insert<T>(
+  connection: Knex,
+  table: string,
+  data: object | object[],
+  trx?: Knex.Transaction
+): Promise<T[]> {
+  const qb = queryBuilder(connection, trx);
+  const result = await qb.insert(object.toSnakeCase(data)).into(table).returning('*');
+
+  return object.toCamelCase(result);
+}
+
+/**
+ * Update records by id.
+ *
+ * @param {Knex} connection
+ * @param {string} table
+ * @param {(number | number[])} id
+ * @param {object} params
+ * @param {Knex.Transaction} [trx]
+ * @returns {Promise<T[]>}
+ */
+export async function updateById<T>(
+  connection: Knex,
+  table: string,
+  id: number | number[],
+  params: object,
+  trx?: Knex.Transaction
+): Promise<T[]> {
+  const qb = queryBuilder(connection, trx);
+  const updateParams = await withTimestamp(connection, table, params);
+
+  const result = await qb
+    .table(table)
+    .update(updateParams)
+    .whereIn('id', Array.isArray(id) ? id : [id])
+    .returning('*');
+
+  return object.toCamelCase(result);
+}
+
+/**
+ * Delete row in table.
+ *
+ * @param {Knex} connection
+ * @param {string} table
+ * @param {object} params
+ * @param {Transaction} trx
+ * @returns {Promise<T[]>}
+ */
+export async function remove<T>(connection: Knex, table: string, params: object, trx?: Knex.Transaction): Promise<T[]> {
+  const qb = queryBuilder(connection, trx);
+  const result = await qb.from(table).where(object.toSnakeCase(params)).del().returning('*');
+
+  return object.toCamelCase(result);
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,17 @@
+import pino, { Logger, LoggerOptions, DestinationStream } from 'pino';
+
+const logger = pino();
+
+/**
+ * Returns the child logger instance that has the properties passed in as args.
+ *
+ * @param {Mapping<any>} [bindings = {}]
+ * @returns {Logger<LoggerOptions | DestinationStream>} logger
+ */
+function childLogger(bindings: any = {}): Logger<LoggerOptions | DestinationStream> {
+  const logBindings = { ...bindings };
+
+  return logger.child(logBindings);
+}
+
+export { logger as default, childLogger };

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -1,0 +1,102 @@
+import snakeize = require('snakeize');
+import camelize = require('camelize');
+
+/**
+ * Recursively convert the object keys into camelCase.
+ *
+ * @param {any} object
+ * @returns {T}
+ */
+export function toCamelCase<T>(object: any): T {
+  return camelize(object);
+}
+
+/**
+ * Recursively convert the object keys into snake_case.
+ *
+ * @param {any} object
+ * @returns {T}
+ */
+export function toSnakeCase<T>(object: any): T {
+  return snakeize(object);
+}
+
+/**
+ * Get the copy of list of objects without attributes.
+ *
+ * @param {object[]} obj
+ * @param {any[]} attrsToExclude
+ * @returns {T[]}
+ */
+export function listWithoutAttrs<T>(obj: object[], attrsToExclude: any[]): T[] {
+  return obj.map((item) => withoutAttrs<T>(item, attrsToExclude));
+}
+
+/**
+ * Get the copy of object without attributes.
+ *
+ * @param {any} obj
+ * @param {any[]} attrsToExclude
+ * @returns {T}
+ */
+export function withoutAttrs<T>(obj: any, attrsToExclude: any[]): T {
+  if (Array.isArray(obj)) {
+    // It is recommended to use listWithoutAttrs() function instead for arrays.
+    throw new TypeError('withoutAttrs() expects first argument to be a plain object, array given.');
+  }
+
+  const result: any = {};
+
+  Object.keys(obj).forEach((key: string) => {
+    if (!attrsToExclude.includes(key)) {
+      result[key] = obj[key];
+    }
+  });
+
+  return result;
+}
+
+/**
+ * Get the copy of object with only specified attributes.
+ *
+ * @param {any} obj
+ * @param {any[]} attrs
+ * @returns {T}
+ */
+export function withOnlyAttrs<T>(obj: any, attrs: any[]): T {
+  const result: any = {};
+
+  Object.keys(obj).forEach((key) => {
+    if (attrs.includes(key)) {
+      result[key] = obj[key];
+    }
+  });
+
+  return result;
+}
+
+/**
+ * Parse JSON encoded string and return object with camelized keys.
+ *
+ * @param {string} encoded
+ * @returns {T}
+ */
+export function fromJson<T>(encoded: string): T {
+  const parsedObject = JSON.parse(encoded);
+
+  return toCamelCase<T>(parsedObject);
+}
+
+/**
+ * Get number of keys from given value.
+ *
+ * @param {any} value
+ * @returns {number}
+ */
+export function getKeysLength(value: any): number {
+  if (!(value instanceof Object)) {
+    return 0;
+  }
+
+  return Object.keys(value).length;
+}

--- a/src/utils/redis.ts
+++ b/src/utils/redis.ts
@@ -1,0 +1,148 @@
+import Redis from 'ioredis';
+
+import logger from './logger';
+import config from '../config';
+
+export const REVOKED = 'REVOKED';
+export const SESSION_PREFIX = 'session_id_';
+
+let redis: Redis;
+const env = config.env;
+
+/**
+ * Initialize redis.
+ *
+ * @returns {Promise<string>}
+ */
+export function init(): Promise<string> {
+  const redisConfig = config.redis[env];
+
+  // Check for namespace - it is required.
+  if (!redisConfig.namespace) {
+    logger.error('REDIS: Application namespace for redis cannot be empty.');
+
+    throw new Error('App namespace is not set for redis.');
+  }
+
+  // Check for redis's password - it is required.
+  if (!redisConfig.password) {
+    logger.error('REDIS: password cannot be empty.');
+
+    throw new Error('Password is not set for redis.');
+  }
+
+  redis = new Redis(redisConfig);
+
+  logger.debug(`REDIS: Running "ping"..`);
+
+  logger.info(`REDIS: connecting to redis: ${redisConfig.host}`);
+
+  return new Promise((resolve, reject) => {
+    redis.ping((err, res) => {
+      if (err) {
+        logger.error(`REDIS: Could not ping the server: ${err.message}`);
+
+        return reject(err);
+      }
+
+      if (!res) {
+        logger.error('Something went wrong');
+
+        return reject('Something went wrong');
+      }
+
+      return resolve(res);
+    });
+  });
+}
+
+export function disconnect() {
+  redis.disconnect();
+}
+
+/**
+ * Create session key name.
+ *
+ * @param {number | string} sessionId
+ * @param {number | string} appId
+ * @returns {string}
+ */
+export function createSessionKeyName(sessionId: number | string) {
+  return `${SESSION_PREFIX}${sessionId}`;
+}
+
+/**
+ * Set the string value of the key. Optionally, can give key's expire time (ms).
+ *
+ * @param {string} key
+ * @param {string} value
+ * @param {number} expireTime
+ * @returns {Promise<string>}
+ */
+export function set(key: string, value: string, expireTime?: number): Promise<string> {
+  const namespacedKey = withNamespace(key);
+
+  if (expireTime) {
+    logger.debug(`Redis: Setting '${namespacedKey}' with expiration`);
+
+    return redis.set(namespacedKey, value, 'EX', expireTime / 1000);
+  }
+
+  logger.debug(`Redis: Setting '${namespacedKey}'`);
+
+  return redis.set(namespacedKey, value);
+}
+
+/**
+ * Get the value of given key.
+ *
+ * @param {string} key
+ * @returns {Promise<string>}
+ */
+export async function get(key: string): Promise<string | null> {
+  const namespacedKey = withNamespace(key);
+
+  logger.debug(`$Redis: Retrieving '${namespacedKey}'`);
+
+  return redis.get(namespacedKey);
+}
+
+/**
+ * Get the key prefixed with a namespace for storing/retrieving in redis.
+ *
+ * @param {string} key
+ * @returns {string}
+ */
+function withNamespace(key: string): string {
+  const { namespace } = config.redis[env];
+
+  return `${namespace}:${key}`;
+}
+
+/**
+ * Delete keys matching a given pattern.
+ *
+ * @param {string} pattern
+ * @returns {Promise<any>}
+ */
+export async function del(pattern: string): Promise<any> {
+  if (!pattern) {
+    throw new Error('Pattern argument cannot be empty.');
+  }
+
+  const { namespace } = config.redis[env];
+  const keys = await redis.keys(`${namespace}:${pattern}`);
+  const pipeline = redis.pipeline();
+
+  logger.debug(`Deleting keys of pattern: ${namespace}:${pattern}`);
+
+  keys.forEach((key: string) => {
+    pipeline.del(key);
+
+    logger.debug(`Key Deleted: ${key}`);
+  });
+
+  logger.info(`Deleted ${keys.length} keys`);
+
+  return pipeline.exec();
+}


### PR DESCRIPTION
# Description
 For the connection to the database to be established a separate function was created along with `redis` to store the connection parameter.
Helper DB functions are added for `postgres` and `redis`.

Tasks Done

- Add connection parameter function
- Add redis function to store data
- Add db related functions to help query
- Add object helper function